### PR TITLE
semantic search capabilities to the Neo4j graph pipeline by adding node embedding and search scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ galaxy_tools_may_3_2025_v1.json
 models/
 test_data
 iwc_full_*.json
+step_*.csv
+workflow_*.csv
+workflows.csv
+tools_*.csv
+cypher_out
+tool_*.csv

--- a/Makefile
+++ b/Makefile
@@ -53,5 +53,17 @@ pipeline: tools_csv workflows_csv load_graph
 
 .PHONY: activate fetch_tools tools_csv workflows_csv load_graph pipeline
 
+# Downloader targets
+download_tools:
+	$(PY) utilities/tools_metadata_downloader/tool_downloader.py || echo "Warning: tools downloader failed"
+
+download_workflows:
+	$(PY) utilities/workflow_downloader/iwc_downloader.py|| echo "Warning: workflow downloader failed"
+
+# Full pipeline including downloads
+pipeline_full: download_tools download_workflows pipeline
+
+.PHONY: download_tools download_workflows pipeline_full
+
 
 .PHONY: activate fetch_tools

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,17 @@
 VENV_NAME := venv
 REQUIREMENTS := requirements.txt
 
+PY := python3
+CSV_DIR := agents/generic_loader/data
+
+# Pick the latest downloaded JSONs if present; tolerate missing files.
+TOOLS_JSON ?= $(shell ls -1t utilities/tools_metadata_downloader/data/galaxy_instance_tools_*.json 2>/dev/null | head -1)
+WORKFLOW_JSON ?= $(shell ls -1t utilities/workflow_downloader/data/iwc_full_*.json 2>/dev/null | head -1)
+
+NEO4J_URI ?= bolt://localhost:7687
+NEO4J_USER ?= neo4j
+# NEO4J_PASSWORD should be provided in the environment or via CLI: make load_graph NEO4J_PASSWORD=...
+
 activate:
 	@echo "Setting up virtual environment..."
 	 python3 -m venv $(VENV_NAME) && \
@@ -12,6 +23,35 @@ activate:
 
 fetch_tools:
 	python3 tool_downloader.py
+
+tools_csv:
+	@if [ -n "$(TOOLS_JSON)" ]; then \
+		echo "Using tools JSON: $(TOOLS_JSON)"; \
+		$(PY) agents/generic_loader/convert_tools_json_to_csv.py $(TOOLS_JSON) --output-dir $(CSV_DIR); \
+	else \
+		echo "Skipping tools_csv: no tools JSON found in utilities/tools_metadata_downloader/data"; \
+	fi
+
+workflows_csv:
+	@if [ -n "$(WORKFLOW_JSON)" ]; then \
+		echo "Using workflow JSON: $(WORKFLOW_JSON)"; \
+		$(PY) agents/generic_loader/convert_json_to_csv.py $(WORKFLOW_JSON) --output-dir $(CSV_DIR); \
+	else \
+		echo "Skipping workflows_csv: no workflow JSON found in utilities/workflow_downloader/data"; \
+	fi
+
+load_graph:
+	@if [ -z "$(NEO4J_PASSWORD)" ]; then echo "NEO4J_PASSWORD is required"; exit 1; fi
+	$(PY) agents/generic_loader/generic_csv_loader.py \
+		--csv-dir $(CSV_DIR) \
+		--uri $(NEO4J_URI) \
+		--user $(NEO4J_USER) \
+		--password "$(NEO4J_PASSWORD)"
+
+# Full pipeline: convert latest tools/workflows to CSV then load
+pipeline: tools_csv workflows_csv load_graph
+
+.PHONY: activate fetch_tools tools_csv workflows_csv load_graph pipeline
 
 
 .PHONY: activate fetch_tools

--- a/agents/generic_loader/README.md
+++ b/agents/generic_loader/README.md
@@ -16,6 +16,8 @@ A reusable, config-driven pipeline to convert scraped workflow JSON into CSVs an
 - `generic_csv_loader.py`: Config-driven CSV → Neo4j loader that merges nodes first, then edges.
 - `generate_cypher_files.py`: Emits `nodes.cypher` and `edges.cypher` (MERGE statements) from CSVs using the same config/IDs.
 - `cypher_batch_loader.py`: Runs the generated Cypher files (nodes first, then edges) against Neo4j.
+- `embed_nodes.py`: Computes embeddings with a free open model and stores them on nodes for semantic search.
+- `search.py`: CLI to embed a query and return top-K similar nodes by label using stored embeddings.
 
 ## ID Strategy (deterministic)
 - `Category`: `category_id = md5(category)`
@@ -61,6 +63,30 @@ python agents/generic_loader/cypher_batch_loader.py \
   --user neo4j \
   --password YOUR_PASSWORD
 ```
+```
+
+4) Optional: add embeddings for semantic search (defaults to MiniLM):
+```bash
+python agents/generic_loader/embed_nodes.py \
+  --uri bolt://localhost:7687 \
+  --user neo4j \
+  --password YOUR_PASSWORD \
+  --labels Workflow Step Tool Input Output Category \
+  --model sentence-transformers/all-MiniLM-L6-v2 \
+  --create-index
+```
+
+This stores a float-vector property `embedding` on each node and attempts to create native vector indexes when supported by your Neo4j version.
+
+5) Optional: run a semantic search
+```bash
+python agents/generic_loader/search.py \
+  --label Step \
+  --q "align sequences" \
+  --k 10 \
+  --uri bolt://localhost:7687 \
+  --user neo4j \
+  --password YOUR_PASSWORD
 ```
 
 ## Customization

--- a/agents/generic_loader/convert_json_to_csv.py
+++ b/agents/generic_loader/convert_json_to_csv.py
@@ -2,7 +2,18 @@ import argparse
 import csv
 import json
 from pathlib import Path
-from typing import List, Dict, Any, Iterable
+from typing import List, Dict, Any, Iterable, Type
+
+from convertor_schema import (
+    InputConnectionProperties,
+    InputProperties,
+    OutputProperties,
+    StepsInWorkflowFileProperties,
+    ToolsInStepsProperties,
+    ToolsInWorkflowFileProperties,
+    WorkflowFileProperties,
+    WorkflowProperties,
+)
 
 
 def load_json(path: Path) -> List[Dict[str, Any]]:
@@ -24,30 +35,42 @@ def derive_tools_from_steps(steps: List[Dict[str, Any]]) -> List[Dict[str, Any]]
             continue
         seen_ids.add(tool_id)
         repo = step.get("tool_shed_repository") or {}
-        tools.append({
-            "id": str(tool_id),
-            "name": step.get("name") or "",
-            "version": step.get("tool_version") or "",
-            "owner": repo.get("owner", ""),
-            "category": repo.get("category", ""),
-            "tool_shed_url": repo.get("tool_shed", ""),
-        })
+        schema_validated_tools = ToolsInStepsProperties(
+            id=str(tool_id),
+            name=step.get("name") or "",
+            version=step.get("tool_version") or "",
+            owner=repo.get("owner", ""),
+            category=repo.get("category", ""),
+            tool_shed_url=repo.get("tool_shed", ""),
+        )
+
+        tools.append(schema_validated_tools.dict())
     return tools
+
+
+def _validated_dict(model: Type, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate payload with pydantic model and return its dict."""
+    return model(**payload).dict()
 
 
 def to_workflows_csv_rows(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     rows = []
     for wf in data:
-        rows.append({
-            "category": wf.get("category", ""),
-            "workflow_repository": wf.get("workflow_repository", ""),
-            "has_readme": wf.get("has_readme", False),
-            "has_dockstore_yml": wf.get("has_dockstore_yml", False),
-            "has_test_data": wf.get("has_test_data", False),
-            "has_changelog": wf.get("has_changelog", False),
-            "planemo_tests": ";".join(wf.get("planemo_tests", [])),
-            "readme_content": wf.get("readme_content", "") or "",
-        })
+        rows.append(
+            _validated_dict(
+                WorkflowProperties,
+                {
+                    "category": wf.get("category", ""),
+                    "workflow_repository": wf.get("workflow_repository", ""),
+                    "has_readme": wf.get("has_readme", False),
+                    "has_dockstore_yml": wf.get("has_dockstore_yml", False),
+                    "has_test_data": wf.get("has_test_data", False),
+                    "has_changelog": wf.get("has_changelog", False),
+                    "planemo_tests": ";".join(wf.get("planemo_tests", [])),
+                    "readme_content": wf.get("readme_content", "") or "",
+                },
+            )
+        )
     return rows
 
 
@@ -55,15 +78,23 @@ def to_workflow_files_csv_rows(data: List[Dict[str, Any]]) -> List[Dict[str, Any
     rows = []
     for wf in data:
         for wf_file in wf.get("workflow_files", []) or []:
-            rows.append({
-                "category": wf.get("category", ""),
-                "workflow_repository": wf.get("workflow_repository", ""),
-                "workflow_name": wf_file.get("workflow_name", ""),
-                "number_of_steps": wf_file.get("number_of_steps", 0),
-                "file_name": wf_file.get("file_name", ""),
-                "raw_download_url": wf_file.get("raw_download_url", ""),
-                "tools_used_count": len(wf_file.get("tools_used") or derive_tools_from_steps(wf_file.get("steps", []))),
-            })
+            rows.append(
+                _validated_dict(
+                    WorkflowFileProperties,
+                    {
+                        "category": wf.get("category", ""),
+                        "workflow_repository": wf.get("workflow_repository", ""),
+                        "workflow_name": wf_file.get("workflow_name", ""),
+                        "number_of_steps": wf_file.get("number_of_steps", 0),
+                        "file_name": wf_file.get("file_name", ""),
+                        "raw_download_url": wf_file.get("raw_download_url", ""),
+                        "tools_used_count": len(
+                            wf_file.get("tools_used")
+                            or derive_tools_from_steps(wf_file.get("steps", []))
+                        ),
+                    },
+                )
+            )
     return rows
 
 
@@ -75,18 +106,23 @@ def to_tools_used_csv_rows(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             if tools is None:
                 tools = derive_tools_from_steps(wf_file.get("steps", []))
             for tool in tools or []:
-                rows.append({
-                    "category": wf.get("category", ""),
-                    "workflow_repository": wf.get("workflow_repository", ""),
-                    "workflow_name": wf_file.get("workflow_name", ""),
-                    "file_name": wf_file.get("file_name", ""),
-                    "id": tool.get("id", ""),
-                    "name": tool.get("name", ""),
-                    "version": tool.get("version", ""),
-                    "owner": tool.get("owner", ""),
-                    "tool_category": tool.get("category", ""),
-                    "tool_shed_url": tool.get("tool_shed_url", ""),
-                })
+                rows.append(
+                    _validated_dict(
+                        ToolsInWorkflowFileProperties,
+                        {
+                            "category": wf.get("category", ""),
+                            "workflow_repository": wf.get("workflow_repository", ""),
+                            "workflow_name": wf_file.get("workflow_name", ""),
+                            "file_name": wf_file.get("file_name", ""),
+                            "id": tool.get("id", ""),
+                            "name": tool.get("name", ""),
+                            "version": tool.get("version", ""),
+                            "owner": tool.get("owner", ""),
+                            "tool_category": tool.get("category", ""),
+                            "tool_shed_url": tool.get("tool_shed_url", ""),
+                        },
+                    )
+                )
     return rows
 
 
@@ -105,20 +141,25 @@ def to_steps_csv_rows(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     for wf in data:
         for wf_file in wf.get("workflow_files", []) or []:
             for step in wf_file.get("steps", []) or []:
-                rows.append({
-                    "category": wf.get("category", ""),
-                    "workflow_repository": wf.get("workflow_repository", ""),
-                    "workflow_name": wf_file.get("workflow_name", ""),
-                    "file_name": wf_file.get("file_name", ""),
-                    "step_id": step.get("step_id"),
-                    "type": step.get("type", ""),
-                    "name": step.get("name", ""),
-                    "annotation": step.get("annotation", ""),
-                    "tool_id": step.get("tool_id", ""),
-                    "tool_version": step.get("tool_version", ""),
-                    "inputs_count": len(step.get("inputs", []) or []),
-                    "outputs_count": len(step.get("outputs", []) or []),
-                })
+                rows.append(
+                    _validated_dict(
+                        StepsInWorkflowFileProperties,
+                        {
+                            "category": wf.get("category", ""),
+                            "workflow_repository": wf.get("workflow_repository", ""),
+                            "workflow_name": wf_file.get("workflow_name", ""),
+                            "file_name": wf_file.get("file_name", ""),
+                            "step_id": step.get("step_id"),
+                            "type": step.get("type", ""),
+                            "name": step.get("name", ""),
+                            "annotation": step.get("annotation", ""),
+                            "tool_id": step.get("tool_id", ""),
+                            "tool_version": step.get("tool_version", ""),
+                            "inputs_count": len(step.get("inputs", []) or []),
+                            "outputs_count": len(step.get("outputs", []) or []),
+                        },
+                    )
+                )
     return rows
 
 
@@ -128,14 +169,19 @@ def to_step_inputs_csv_rows(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         for wf_file in wf.get("workflow_files", []) or []:
             for step in wf_file.get("steps", []) or []:
                 for io in _flatten_ios(step.get("inputs", [])):
-                    rows.append({
-                        "category": wf.get("category", ""),
-                        "workflow_repository": wf.get("workflow_repository", ""),
-                        "workflow_name": wf_file.get("workflow_name", ""),
-                        "file_name": wf_file.get("file_name", ""),
-                        "step_id": step.get("step_id"),
-                        **io,
-                    })
+                    rows.append(
+                        _validated_dict(
+                            InputProperties,
+                            {
+                                "category": wf.get("category", ""),
+                                "workflow_repository": wf.get("workflow_repository", ""),
+                                "workflow_name": wf_file.get("workflow_name", ""),
+                                "file_name": wf_file.get("file_name", ""),
+                                "step_id": step.get("step_id"),
+                                **io,
+                            },
+                        )
+                    )
     return rows
 
 
@@ -145,14 +191,19 @@ def to_step_outputs_csv_rows(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]
         for wf_file in wf.get("workflow_files", []) or []:
             for step in wf_file.get("steps", []) or []:
                 for io in _flatten_ios(step.get("outputs", [])):
-                    rows.append({
-                        "category": wf.get("category", ""),
-                        "workflow_repository": wf.get("workflow_repository", ""),
-                        "workflow_name": wf_file.get("workflow_name", ""),
-                        "file_name": wf_file.get("file_name", ""),
-                        "step_id": step.get("step_id"),
-                        **io,
-                    })
+                    rows.append(
+                        _validated_dict(
+                            OutputProperties,
+                            {
+                                "category": wf.get("category", ""),
+                                "workflow_repository": wf.get("workflow_repository", ""),
+                                "workflow_name": wf_file.get("workflow_name", ""),
+                                "file_name": wf_file.get("file_name", ""),
+                                "step_id": step.get("step_id"),
+                                **io,
+                            },
+                        )
+                    )
     return rows
 
 
@@ -165,16 +216,21 @@ def to_input_connections_csv_rows(data: List[Dict[str, Any]]) -> List[Dict[str, 
                 for input_name, conn in (conns.items() if isinstance(conns, dict) else []):
                     conn_list = conn if isinstance(conn, list) else [conn]
                     for c in conn_list:
-                        rows.append({
-                            "category": wf.get("category", ""),
-                            "workflow_repository": wf.get("workflow_repository", ""),
-                            "workflow_name": wf_file.get("workflow_name", ""),
-                            "file_name": wf_file.get("file_name", ""),
-                            "step_id": step.get("step_id"),
-                            "input_name": input_name,
-                            "from_step_id": c.get("id"),
-                            "from_output_name": c.get("output_name", ""),
-                        })
+                        rows.append(
+                            _validated_dict(
+                                InputConnectionProperties,
+                                {
+                                    "category": wf.get("category", ""),
+                                    "workflow_repository": wf.get("workflow_repository", ""),
+                                    "workflow_name": wf_file.get("workflow_name", ""),
+                                    "file_name": wf_file.get("file_name", ""),
+                                    "step_id": step.get("step_id"),
+                                    "input_name": input_name,
+                                    "from_step_id": c.get("id"),
+                                    "from_output_name": c.get("output_name", ""),
+                                },
+                            )
+                        )
     return rows
 
 

--- a/agents/generic_loader/convert_json_to_csv.py
+++ b/agents/generic_loader/convert_json_to_csv.py
@@ -185,7 +185,13 @@ def write_csv(rows: List[Dict[str, Any]], path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     fieldnames = list(rows[0].keys())
     with path.open("w", encoding="utf-8", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer = csv.DictWriter(
+            f,
+            fieldnames=fieldnames,
+            quoting=csv.QUOTE_ALL,
+            escapechar="\\",
+            lineterminator="\n",
+        )
         writer.writeheader()
         writer.writerows(rows)
     print(f"✅ Wrote {len(rows)} rows to {path}")

--- a/agents/generic_loader/convert_tools_json_to_csv.py
+++ b/agents/generic_loader/convert_tools_json_to_csv.py
@@ -2,7 +2,14 @@ import argparse
 import csv
 import json
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import Any, Dict, List, Type
+
+from convertor_schema import (
+    ToolCategoryRow,
+    ToolInputRow,
+    ToolMasterProperties,
+    ToolOutputRow,
+)
 
 
 def load_json(path: Path) -> List[Dict[str, Any]]:
@@ -32,6 +39,10 @@ def write_csv(rows: List[Dict[str, Any]], path: Path) -> None:
     print(f"✅ Wrote {len(rows)} rows to {path}")
 
 
+def _validated_dict(model: Type, payload: Dict[str, Any]) -> Dict[str, Any]:
+    return model(**payload).model_dump()
+
+
 def convert_tools(tools: List[Dict[str, Any]], out_dir: Path):
     # Master tool rows
     tools_master = []
@@ -51,33 +62,54 @@ def convert_tools(tools: List[Dict[str, Any]], out_dir: Path):
         if not cats:
             cats = ["unspecified"]
 
-        tools_master.append({
-            "id": tid,
-            "name": name,
-            "description": desc,
-            "version": ver,
-            "help": help_text,
-        })
+        tools_master.append(
+            _validated_dict(
+                ToolMasterProperties,
+                {
+                    "id": tid,
+                    "name": name,
+                    "description": desc,
+                    "version": ver,
+                    "help": help_text,
+                },
+            )
+        )
 
         for c in cats:
-            tool_categories.append({
-                "id": tid,
-                "category": c,
-            })
+            cat_val = c or ""
+            tool_categories.append(
+                _validated_dict(
+                    ToolCategoryRow,
+                    {
+                        "id": tid,
+                        "category": cat_val,
+                    },
+                )
+            )
 
         for inp in (t.get("inputs") or []):
-            tool_inputs.append({
-                "id": tid,
-                "input_name": inp.get("name") or "",
-                "input_type": inp.get("type") or "",
-            })
+            tool_inputs.append(
+                _validated_dict(
+                    ToolInputRow,
+                    {
+                        "id": tid,
+                        "input_name": inp.get("name") or "",
+                        "input_type": inp.get("type") or "",
+                    },
+                )
+            )
 
         for outp in (t.get("outputs") or []):
-            tool_outputs.append({
-                "id": tid,
-                "output_name": outp.get("name") or "",
-                "output_format": outp.get("format") if outp.get("format") is not None else "",
-            })
+            tool_outputs.append(
+                _validated_dict(
+                    ToolOutputRow,
+                    {
+                        "id": tid,
+                        "output_name": outp.get("name") or "",
+                        "output_format": outp.get("format") if outp.get("format") is not None else "",
+                    },
+                )
+            )
 
     write_csv(tools_master, out_dir / "tools_master.csv")
     write_csv(tool_categories, out_dir / "tool_categories.csv")

--- a/agents/generic_loader/convert_tools_json_to_csv.py
+++ b/agents/generic_loader/convert_tools_json_to_csv.py
@@ -20,7 +20,13 @@ def write_csv(rows: List[Dict[str, Any]], path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     fieldnames = list(rows[0].keys())
     with path.open("w", encoding="utf-8", newline="") as f:
-        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w = csv.DictWriter(
+            f,
+            fieldnames=fieldnames,
+            quoting=csv.QUOTE_ALL,
+            escapechar="\\",
+            lineterminator="\n",
+        )
         w.writeheader()
         w.writerows(rows)
     print(f"✅ Wrote {len(rows)} rows to {path}")

--- a/agents/generic_loader/convertor_schema.py
+++ b/agents/generic_loader/convertor_schema.py
@@ -1,0 +1,214 @@
+from pydantic import BaseModel #type: ignore
+from typing import Any
+
+class WorkflowProperties(BaseModel):
+    category: str
+    workflow_repository: str
+    has_readme: bool
+    has_dockstore_yml: bool
+    has_test_data: bool
+    has_changelog: bool
+    planemo_tests: str
+    readme_content: str
+
+class Workflow(BaseModel):
+    label: str = "workflow"
+    unique_key: Any = ["workflow_repository"]
+    description: str = "A workflow composed of tools and IO"
+    properties: WorkflowProperties
+
+
+class WorkflowFileProperties(BaseModel):
+    category: str
+    workflow_repository: str
+    workflow_name: str
+    number_of_steps: int
+    file_name: str
+    raw_download_url: str
+    tools_used_count: int
+    
+class ToolsInWorkflowFileProperties(BaseModel):
+    category: str
+    workflow_repository: str
+    workflow_name: str
+    file_name: str
+    id: str
+    name: str
+    version: str
+    owner: str
+    tool_category: str
+    tool_shed_url: str
+
+class StepsInWorkflowFileProperties(BaseModel):
+    category: str
+    workflow_repository: str
+    workflow_name: str
+    file_name: str
+    step_id: Any
+    name: str
+    type: str
+    annotation: str
+    tool_id: str | None
+    tool_version: str | None
+    inputs_count: int
+    outputs_count: int
+
+class StepInputsProperties(BaseModel):
+    category: str
+    workflow_repository: str
+    workflow_name: str
+    file_name: str
+    step_id: Any
+
+
+class StepOutputsProperties(BaseModel):
+    category: str
+    workflow_repository: str
+    workflow_name: str
+    file_name: str
+    step_id: Any
+    
+class InputConncectionProperties(BaseModel):
+    category: str
+    workflow_repository: str
+    workflow_name: str
+    file_name: str
+    step_id: Any
+    input_name: str
+    from_step_id: Any
+    from_output_name: str
+
+
+class WorkflowFile(BaseModel):
+    label: str = "workflow_file"
+    unique_key: Any = ["workflow_repository", "file_name"]
+    properties: WorkflowFileProperties
+
+class ToolProperties(BaseModel):
+    id: str | None = None
+    name: str
+    description: str
+    version: str
+    help: str
+    owner: str | None = None
+    tool_category: str | None = None
+    tool_shed_url: str | None = None
+
+
+class ToolsInStepsProperties(BaseModel):
+    id: str
+    name: str
+    version: str
+    owner: str
+    category: str
+    tool_shed_url: str
+
+class Tool(BaseModel):
+    label: str = "tool"
+    unique_key: Any = ["name", "version"]
+    properties: ToolProperties
+
+
+class ToolUsedProperties(BaseModel):
+    category: str
+    workflow_repository: str
+    workflow_name: str
+    file_name: str
+    id: str
+    name: str
+    version: str
+    owner: str
+    tool_category: str
+    tool_shed_url: str
+
+
+class ToolUsed(BaseModel):
+    label: str = "tool_used"
+    unique_key: Any = ["workflow_repository", "file_name", "id", "version"]
+    properties: ToolUsedProperties
+
+class CategoryProperties(BaseModel):
+    name: str
+
+class Category(BaseModel):
+    label: str = "category"
+    unique_key: Any = ["name"]
+    properties: CategoryProperties
+
+class InputProperties(BaseModel):
+    category: str
+    workflow_repository: str
+    workflow_name: str
+    file_name: str
+    step_id: Any
+    name: str
+    type: str
+    description: str
+    optional: bool
+
+class Input(BaseModel):
+    label: str = "input"
+    unique_key: Any = ["workflow_repository", "file_name", "step_id", "name"]
+    properties: InputProperties
+
+class OutputProperties(BaseModel):
+    category: str
+    workflow_repository: str
+    workflow_name: str
+    file_name: str
+    step_id: Any
+    name: str
+    type: str
+    description: str
+    optional: bool
+
+class Output(BaseModel):
+    label: str = "output"
+    unique_key: Any = ["workflow_repository", "file_name", "step_id", "name"]
+    properties: OutputProperties
+
+class KeywordProperties(BaseModel):
+    name: str
+
+class Keyword(BaseModel):
+    label: str = "keyword"
+    unique_key: Any = ["name"]
+    properties: KeywordProperties
+
+class StepProperties(BaseModel):
+    category: str
+    workflow_repository: str
+    workflow_name: str
+    file_name: str
+    step_id: Any
+    name: str
+    type: str
+    annotation: str
+    tool_id: str
+    tool_version: str
+    inputs_count: int
+    outputs_count: int
+
+
+class Step(BaseModel):
+    label: str = "step"
+    unique_key: Any = ["workflow_repository", "file_name", "step_id"]
+    description: str = "A single step in a workflow"
+    properties: StepProperties
+
+
+class InputConnectionProperties(BaseModel):
+    category: str
+    workflow_repository: str
+    workflow_name: str
+    file_name: str
+    step_id: Any
+    input_name: str
+    from_step_id: Any
+    from_output_name: str
+
+
+class InputConnection(BaseModel):
+    label: str = "input_connection"
+    unique_key: Any = ["workflow_repository", "file_name", "step_id", "input_name", "from_step_id", "from_output_name"]
+    properties: InputConnectionProperties

--- a/agents/generic_loader/convertor_schema.py
+++ b/agents/generic_loader/convertor_schema.py
@@ -11,12 +11,6 @@ class WorkflowProperties(BaseModel):
     planemo_tests: str
     readme_content: str
 
-class Workflow(BaseModel):
-    label: str = "workflow"
-    unique_key: Any = ["workflow_repository"]
-    description: str = "A workflow composed of tools and IO"
-    properties: WorkflowProperties
-
 
 class WorkflowFileProperties(BaseModel):
     category: str
@@ -68,22 +62,6 @@ class StepOutputsProperties(BaseModel):
     file_name: str
     step_id: Any
     
-class InputConncectionProperties(BaseModel):
-    category: str
-    workflow_repository: str
-    workflow_name: str
-    file_name: str
-    step_id: Any
-    input_name: str
-    from_step_id: Any
-    from_output_name: str
-
-
-class WorkflowFile(BaseModel):
-    label: str = "workflow_file"
-    unique_key: Any = ["workflow_repository", "file_name"]
-    properties: WorkflowFileProperties
-
 class ToolProperties(BaseModel):
     id: str | None = None
     name: str
@@ -133,33 +111,6 @@ class Tool(BaseModel):
     unique_key: Any = ["name", "version"]
     properties: ToolProperties
 
-
-class ToolUsedProperties(BaseModel):
-    category: str
-    workflow_repository: str
-    workflow_name: str
-    file_name: str
-    id: str
-    name: str
-    version: str
-    owner: str
-    tool_category: str
-    tool_shed_url: str
-
-
-class ToolUsed(BaseModel):
-    label: str = "tool_used"
-    unique_key: Any = ["workflow_repository", "file_name", "id", "version"]
-    properties: ToolUsedProperties
-
-class CategoryProperties(BaseModel):
-    name: str
-
-class Category(BaseModel):
-    label: str = "category"
-    unique_key: Any = ["name"]
-    properties: CategoryProperties
-
 class InputProperties(BaseModel):
     category: str
     workflow_repository: str
@@ -171,10 +122,6 @@ class InputProperties(BaseModel):
     description: str
     optional: bool
 
-class Input(BaseModel):
-    label: str = "input"
-    unique_key: Any = ["workflow_repository", "file_name", "step_id", "name"]
-    properties: InputProperties
 
 class OutputProperties(BaseModel):
     category: str
@@ -187,40 +134,6 @@ class OutputProperties(BaseModel):
     description: str
     optional: bool
 
-class Output(BaseModel):
-    label: str = "output"
-    unique_key: Any = ["workflow_repository", "file_name", "step_id", "name"]
-    properties: OutputProperties
-
-class KeywordProperties(BaseModel):
-    name: str
-
-class Keyword(BaseModel):
-    label: str = "keyword"
-    unique_key: Any = ["name"]
-    properties: KeywordProperties
-
-class StepProperties(BaseModel):
-    category: str
-    workflow_repository: str
-    workflow_name: str
-    file_name: str
-    step_id: Any
-    name: str
-    type: str
-    annotation: str
-    tool_id: str
-    tool_version: str
-    inputs_count: int
-    outputs_count: int
-
-
-class Step(BaseModel):
-    label: str = "step"
-    unique_key: Any = ["workflow_repository", "file_name", "step_id"]
-    description: str = "A single step in a workflow"
-    properties: StepProperties
-
 
 class InputConnectionProperties(BaseModel):
     category: str
@@ -231,9 +144,3 @@ class InputConnectionProperties(BaseModel):
     input_name: str
     from_step_id: Any
     from_output_name: str
-
-
-class InputConnection(BaseModel):
-    label: str = "input_connection"
-    unique_key: Any = ["workflow_repository", "file_name", "step_id", "input_name", "from_step_id", "from_output_name"]
-    properties: InputConnectionProperties

--- a/agents/generic_loader/convertor_schema.py
+++ b/agents/generic_loader/convertor_schema.py
@@ -103,6 +103,31 @@ class ToolsInStepsProperties(BaseModel):
     category: str
     tool_shed_url: str
 
+
+class ToolMasterProperties(BaseModel):
+    id: str | None = None
+    name: str
+    description: str
+    version: str
+    help: str
+
+
+class ToolCategoryRow(BaseModel):
+    id: str
+    category: str
+
+
+class ToolInputRow(BaseModel):
+    id: str
+    input_name: str
+    input_type: str
+
+
+class ToolOutputRow(BaseModel):
+    id: str
+    output_name: str
+    output_format: str | None = None
+
 class Tool(BaseModel):
     label: str = "tool"
     unique_key: Any = ["name", "version"]

--- a/agents/generic_loader/cypher_batch_loader.py
+++ b/agents/generic_loader/cypher_batch_loader.py
@@ -1,7 +1,7 @@
 """Execute generated Cypher files (nodes then edges) against Neo4j.
 
-This mirrors the file-driven loader style: it reads *.cypher files, splits on
-semicolons, and runs each statement in order. Pair it with
+Reads *.cypher files one statement per line (trimming a trailing semicolon) so
+embedded semicolons inside string values do not break parsing. Pair it with
 `generate_cypher_files.py` outputs.
 
 Usage (from repo root):
@@ -14,25 +14,65 @@ Usage (from repo root):
 
 import argparse
 import logging
+import time
 from pathlib import Path
-from typing import List
 
 from neo4j import GraphDatabase
+from tqdm import tqdm
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
+def iter_statements(path: Path):
+    """Yield statements separated by blank lines, trimming trailing semicolons."""
+    buffer: list[str] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                buffer.append(line.rstrip())
+                continue
+            if buffer:
+                stmt = "\n".join(buffer).strip()
+                if stmt.endswith(";"):
+                    stmt = stmt[:-1]
+                yield stmt
+                buffer = []
+        if buffer:
+            stmt = "\n".join(buffer).strip()
+            if stmt.endswith(";"):
+                stmt = stmt[:-1]
+            yield stmt
 
-def split_statements(text: str) -> List[str]:
-    # Simple semicolon splitter; assumes statements end with ';'
-    parts = text.split(";")
-    return [p.strip() for p in parts if p.strip()]
+
+def count_statements(path: Path) -> int:
+    return sum(1 for _ in iter_statements(path))
 
 
-def run_statements(driver, statements: List[str]):
+def run_statements(driver, path: Path, label: str):
+    total = count_statements(path)
+    start = time.perf_counter()
     with driver.session() as session:
-        for stmt in statements:
+        for stmt in tqdm(iter_statements(path), total=total, desc=label, unit="stmt"):
             session.run(stmt).consume()
+    log.info("[%s] done in %.2fs", label, time.perf_counter() - start)
+
+
+def ensure_indexes(driver):
+    """Create id indexes to speed up MERGE-heavy batches."""
+    index_statements = [
+        "CREATE INDEX cat_id IF NOT EXISTS FOR (n:Category) ON (n.category_id)",
+        "CREATE INDEX wf_id IF NOT EXISTS FOR (n:Workflow) ON (n.workflow_id)",
+        "CREATE INDEX step_id IF NOT EXISTS FOR (n:Step) ON (n.step_uid)",
+        "CREATE INDEX tool_id IF NOT EXISTS FOR (n:Tool) ON (n.tool_id)",
+        "CREATE INDEX tin_id IF NOT EXISTS FOR (n:ToolInput) ON (n.tool_input_uid)",
+        "CREATE INDEX tout_id IF NOT EXISTS FOR (n:ToolOutput) ON (n.tool_output_uid)",
+        "CREATE INDEX in_id IF NOT EXISTS FOR (n:Input) ON (n.input_uid)",
+        "CREATE INDEX out_id IF NOT EXISTS FOR (n:Output) ON (n.output_uid)",
+    ]
+    with driver.session() as session:
+        for stmt in index_statements:
+            session.run(stmt).consume()
+    log.info("Indexes ensured")
 
 
 def main():
@@ -41,6 +81,7 @@ def main():
     parser.add_argument("--uri", default="bolt://localhost:7687")
     parser.add_argument("--user", default="neo4j")
     parser.add_argument("--password", required=True)
+    parser.add_argument("--create-indexes", action="store_true", help="Create IF NOT EXISTS indexes for node ids before loading")
     args = parser.parse_args()
 
     cy_dir = Path(args.cypher_dir)
@@ -50,17 +91,12 @@ def main():
     if not nodes_path.exists() or not edges_path.exists():
         raise SystemExit(f"Expected nodes.cypher and edges.cypher in {cy_dir}")
 
-    nodes_text = nodes_path.read_text(encoding="utf-8")
-    edges_text = edges_path.read_text(encoding="utf-8")
-    nodes_stmts = split_statements(nodes_text)
-    edges_stmts = split_statements(edges_text)
-
     driver = GraphDatabase.driver(args.uri, auth=(args.user, args.password))
     try:
-        log.info("Running %d node statements", len(nodes_stmts))
-        run_statements(driver, nodes_stmts)
-        log.info("Running %d edge statements", len(edges_stmts))
-        run_statements(driver, edges_stmts)
+        if args.create_indexes:
+            ensure_indexes(driver)
+        run_statements(driver, nodes_path, "nodes")
+        run_statements(driver, edges_path, "edges")
         log.info("✅ Cypher batch load complete")
     finally:
         driver.close()

--- a/agents/generic_loader/embed_nodes.py
+++ b/agents/generic_loader/embed_nodes.py
@@ -1,0 +1,284 @@
+"""Compute and store text embeddings on graph nodes for semantic search.
+
+Uses a free, widely adopted open model: sentence-transformers/all-MiniLM-L6-v2
+(384-dim, cosine-friendly). You can switch models via --model.
+
+Embeddings are stored on each node as a float list property `embedding`.
+Optionally attempts to create per-label vector indexes if supported by your
+Neo4j version.
+
+Usage (from repo root):
+  python agents/generic_loader/embed_nodes.py \
+    --uri bolt://localhost:7687 \
+    --user neo4j \
+    --password YOUR_PASSWORD \
+    --labels Workflow Step Tool Input Output Category \
+    --model sentence-transformers/all-MiniLM-L6-v2 \
+    --create-index
+"""
+
+import argparse
+import logging
+from typing import Dict, Any, List, Tuple
+
+from neo4j import GraphDatabase
+from sentence_transformers import SentenceTransformer
+
+from schema_models import DEFAULT_CONFIG, NodeSpec
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
+
+
+def id_prop_by_label() -> Dict[str, str]:
+    return {spec.label: spec.id_property for spec in DEFAULT_CONFIG.nodes}
+
+
+def build_text(label: str, props: Dict[str, Any]) -> str:
+    # Heuristics per label to form a meaningful description for embedding
+    if label == "Workflow":
+        return " ".join(filter(None, [props.get("workflow_repository"), props.get("file_name"), props.get("category")]))
+    if label == "Step":
+        return " ".join(filter(None, [props.get("name"), props.get("type"), props.get("annotation"), props.get("tool_id"), props.get("tool_version")]))
+    if label == "Input":
+        return " ".join(filter(None, [props.get("name"), props.get("description")]))
+    if label == "Output":
+        return " ".join(filter(None, [props.get("name"), props.get("description")]))
+    if label == "Tool":
+        return " ".join(filter(None, [props.get("name"), props.get("version"), props.get("owner"), props.get("tool_category"), props.get("tool_shed_url")]))
+    if label == "Category":
+        return props.get("name") or props.get("category") or ""
+    # Fallback: join all string-like props
+    parts = []
+    for k, v in props.items():
+        if isinstance(v, (str, int, float)):
+            parts.append(str(v))
+    return " ".join(parts)
+
+
+def fetch_nodes(driver, label: str, id_prop: str) -> List[Dict[str, Any]]:
+    q = f"MATCH (n:{label}) RETURN n, n.{id_prop} AS id"
+    rows: List[Dict[str, Any]] = []
+    with driver.session() as session:
+        for rec in session.run(q):
+            node = rec["n"]
+            props = dict(node)
+            rows.append({"id": rec["id"], "props": props})
+    return rows
+
+
+def set_embedding(driver, label: str, id_prop: str, node_id: Any, vec: List[float]):
+    with driver.session() as session:
+        session.run(
+            f"MATCH (n:{label} {{{id_prop}: $id}}) SET n.embedding = $vec",
+            id=node_id,
+            vec=vec,
+        ).consume()
+
+
+def try_create_vector_index(driver, label: str, id_prop: str, dim: int):
+    # Neo4j native vector index (Neo4j 5.15+). Guarded with try/except for older versions.
+    cy = (
+        f"CREATE VECTOR INDEX IF NOT EXISTS {label.lower()}_embedding_index "
+        f"FOR (n:{label}) ON (n.embedding) "
+        f"OPTIONS {{ indexConfig: {{ 'vector.dimensions': {dim}, 'vector.similarityFunction': 'cosine' }} }}"
+    )
+    try:
+        with driver.session() as session:
+            session.run(cy).consume()
+        log.info("Vector index ensured for label %s", label)
+    except Exception as e:
+        log.info("Vector index not created for %s (likely unsupported Neo4j version): %s", label, e)
+
+
+def load_workflow_readmes(csv_dir: str) -> Dict[str, str]:
+    """Map workflow_repository -> readme_content (if available)."""
+    import csv
+    from pathlib import Path
+
+    path = Path(csv_dir) / "workflows.csv"
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    out: Dict[str, str] = {}
+    for r in rows:
+        repo = r.get("workflow_repository") or r.get("repository") or ""
+        readme = r.get("readme_content") or ""
+        if repo:
+            out[repo] = readme
+    return out
+
+
+def fetch_workflow_summaries(driver) -> Dict[str, Tuple[int, List[str], List[str]]]:
+    """Return map of workflow_id -> (steps_count, inputs[], outputs[])."""
+    q = (
+        "MATCH (w:Workflow)\n"
+        "OPTIONAL MATCH (w)-[:HAS_STEP]->(s:Step)\n"
+        "OPTIONAL MATCH (s)-[:STEP_REQUIRES]->(i:Input)\n"
+        "OPTIONAL MATCH (s)-[:STEP_GENERATES]->(o:Output)\n"
+        "RETURN w.workflow_id AS id, count(DISTINCT s) AS steps, "
+        "collect(DISTINCT i.name) AS inputs, collect(DISTINCT o.name) AS outputs"
+    )
+    out: Dict[str, Tuple[int, List[str], List[str]]] = {}
+    with driver.session() as session:
+        for rec in session.run(q):
+            out[rec["id"]] = (rec["steps"], [x for x in rec["inputs"] if x], [y for y in rec["outputs"] if y])
+    return out
+
+
+def build_workflow_text(props: Dict[str, Any], summary: Tuple[int, List[str], List[str]] | None, readme: str | None) -> str:
+    repo = props.get("workflow_repository") or ""
+    fname = props.get("file_name") or ""
+    cat = props.get("category") or ""
+    steps_prop = props.get("number_of_steps")
+    steps_count = summary[0] if summary else steps_prop or 0
+    inputs = summary[1] if summary else []
+    outputs = summary[2] if summary else []
+    # limit IO lists to avoid very long texts
+    inputs_s = ", ".join(inputs[:50])
+    outputs_s = ", ".join(outputs[:50])
+    # trim README to a reasonable size
+    readme = (readme or "").strip()
+    if len(readme) > 4000:
+        readme = readme[:4000]
+    parts = [
+        f"Workflow: {repo}/{fname}",
+        f"Category: {cat}",
+        f"Steps: {steps_count}",
+        f"Inputs: [{inputs_s}]",
+        f"Outputs: [{outputs_s}]",
+        f"README: {readme}",
+    ]
+    return "\n".join(parts)
+
+
+def fetch_step_contexts(driver) -> Dict[str, Dict[str, Any]]:
+    """Map step_uid -> {repo, file_name, inputs, outputs}."""
+    q = (
+        "MATCH (w:Workflow)-[:HAS_STEP]->(s:Step)\n"
+        "OPTIONAL MATCH (s)-[:STEP_REQUIRES]->(i:Input)\n"
+        "OPTIONAL MATCH (s)-[:STEP_GENERATES]->(o:Output)\n"
+        "RETURN s.step_uid AS sid, w.workflow_repository AS repo, w.file_name AS file, "
+        "collect(DISTINCT i.name) AS inputs, collect(DISTINCT o.name) AS outputs"
+    )
+    out: Dict[str, Dict[str, Any]] = {}
+    with driver.session() as session:
+        for rec in session.run(q):
+            out[rec["sid"]] = {
+                "repo": rec["repo"],
+                "file": rec["file"],
+                "inputs": [x for x in rec["inputs"] if x],
+                "outputs": [y for y in rec["outputs"] if y],
+            }
+    return out
+
+
+def build_step_text(props: Dict[str, Any], ctx: Dict[str, Any] | None, readmes: Dict[str, str]) -> str:
+    name = props.get("name") or ""
+    typ = props.get("type") or ""
+    annot = props.get("annotation") or ""
+    tool_id = props.get("tool_id") or ""
+    tool_ver = props.get("tool_version") or ""
+    repo = ctx.get("repo") if ctx else ""
+    file_name = ctx.get("file") if ctx else ""
+    inputs = ctx.get("inputs") if ctx else []
+    outputs = ctx.get("outputs") if ctx else []
+    readme = readmes.get(repo or "") or ""
+    if len(readme) > 1000:
+        readme = readme[:1000]
+    inputs_s = ", ".join(inputs[:30])
+    outputs_s = ", ".join(outputs[:30])
+    parts = [
+        f"Step: {name}",
+        f"Type: {typ}",
+        f"Tool: {tool_id} {tool_ver}".strip(),
+        f"Workflow: {repo}/{file_name}",
+        f"Inputs: [{inputs_s}]",
+        f"Outputs: [{outputs_s}]",
+        f"Notes: {annot}",
+        f"Workflow README: {readme}",
+    ]
+    return "\n".join([p for p in parts if p and p.strip()])
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compute/store node embeddings for semantic search")
+    parser.add_argument("--uri", default="bolt://localhost:7687")
+    parser.add_argument("--user", default="neo4j")
+    parser.add_argument("--password", required=True)
+    parser.add_argument(
+        "--labels",
+        nargs="+",
+        default=[spec.label for spec in DEFAULT_CONFIG.nodes],
+        help="Node labels to embed",
+    )
+    parser.add_argument("--model", default="sentence-transformers/all-MiniLM-L6-v2", help="SentenceTransformer model id")
+    parser.add_argument("--csv-dir", default=str("agents/generic_loader/data"), help="CSV dir to enrich workflows (for README)")
+    parser.add_argument("--create-index", action="store_true", help="Attempt to create vector indexes per label")
+    args = parser.parse_args()
+
+    log.info("Loading embedding model: %s", args.model)
+    model = SentenceTransformer(args.model)
+    is_e5 = "e5" in args.model.lower()
+    dim = model.get_sentence_embedding_dimension()
+    id_map = id_prop_by_label()
+
+    driver = GraphDatabase.driver(args.uri, auth=(args.user, args.password))
+    try:
+        # Pre-enrichment for workflows
+        enrich_wf = "Workflow" in args.labels or "Step" in args.labels
+        readmes = load_workflow_readmes(args.csv_dir) if enrich_wf else {}
+        wf_summaries = fetch_workflow_summaries(driver) if "Workflow" in args.labels else {}
+        step_ctx = fetch_step_contexts(driver) if "Step" in args.labels else {}
+
+        for label in args.labels:
+            id_prop = id_map.get(label)
+            if not id_prop:
+                log.warning("Skipping label %s (no id property in config)", label)
+                continue
+            log.info("Embedding label %s (id prop: %s)", label, id_prop)
+            rows = fetch_nodes(driver, label, id_prop)
+            if not rows:
+                log.info("No nodes found for %s", label)
+                continue
+
+            if label == "Workflow":
+                texts = []
+                for r in rows:
+                    props = r["props"]
+                    wid = r["id"]
+                    summary = wf_summaries.get(wid)
+                    readme = readmes.get(props.get("workflow_repository") or "")
+                    texts.append(build_workflow_text(props, summary, readme))
+                if is_e5:
+                    texts = ["passage: " + t for t in texts]
+            elif label == "Step":
+                texts = []
+                for r in rows:
+                    props = r["props"]
+                    sid = r["id"]
+                    ctx = step_ctx.get(sid)
+                    texts.append(build_step_text(props, ctx, readmes))
+                if is_e5:
+                    texts = ["passage: " + t for t in texts]
+            else:
+                texts = [build_text(label, r["props"]) for r in rows]
+                if is_e5:
+                    texts = ["passage: " + t for t in texts]
+            # Replace empty texts with id to avoid zero vectors
+            texts = [t if t and t.strip() else str(r["id"]) for t, r in zip(texts, rows)]
+
+            embeddings = model.encode(texts, convert_to_numpy=True, normalize_embeddings=True)
+            for r, vec in zip(rows, embeddings):
+                set_embedding(driver, label, id_prop, r["id"], vec.tolist())
+            log.info("Stored embeddings for %d %s nodes", len(rows), label)
+
+            if args.create_index:
+                try_create_vector_index(driver, label, id_prop, dim)
+    finally:
+        driver.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/generic_loader/generate_cypher_files.py
+++ b/agents/generic_loader/generate_cypher_files.py
@@ -1,79 +1,85 @@
 import argparse
-import csv
-import hashlib
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import List
 
 from schema_models import DEFAULT_CONFIG, NodeSpec, RelationshipSpec
 
 
-def md5_id(values: List[Any]) -> str:
-    s = "_".join([str(v) for v in values if v is not None])
-    return hashlib.md5(s.encode("utf-8")).hexdigest()
+def build_md5_expression(source_alias: str, fields: List[str]) -> str:
+    # apoc.util.md5 expects a list; passing a string causes "expected List but was String"
+    joined_fields = ", ".join([f"coalesce({source_alias}.`{f}`, '')" for f in fields])
+    return f"apoc.util.md5([{joined_fields}])"
 
 
-def escape(val: Any) -> str:
-    """Escape a value for Cypher string literal; store everything as string for parity."""
-    if val is None:
-        val = ""
-    return str(val).replace("\\", "\\\\").replace("'", "\\'")
+def node_statement(spec: NodeSpec, csv_url: str, batch_size: int, parallel: bool, concurrency: int) -> str:
+    id_expr = build_md5_expression("row", spec.id_fields)
+    props_entries = [f"`{spec.id_property}`: node_id"]
+    for pf in spec.prop_fields:
+        if spec.label == "Category" and pf == "category":
+            props_entries.append("`name`: coalesce(row.`category`, '')")
+        props_entries.append(f"`{pf}`: coalesce(row.`{pf}`, '')")
+    props_literal = ", ".join(props_entries)
+    action_lines = [
+        f"WITH row, {id_expr} AS node_id",
+        f"MERGE (n:{spec.label} {{{spec.id_property}: node_id}})",
+        f"SET n += {{{props_literal}}}",
+    ]
+    action_query = "\\n".join(action_lines)
+    return (
+        "CALL apoc.periodic.iterate(\n"
+        f"  \"LOAD CSV WITH HEADERS FROM '{csv_url}' AS row RETURN row\",\n"
+        f"  \"{action_query}\",\n"
+        f"  {{batchSize:{batch_size}, parallel:{str(parallel).lower()}, concurrency:{concurrency}}}\n"
+        ");"
+    )
 
 
-def read_csv(path: Path) -> List[Dict[str, Any]]:
-    if not path.exists():
-        return []
-    with path.open("r", encoding="utf-8") as f:
-        return list(csv.DictReader(f))
+def rel_statement(
+    spec: RelationshipSpec,
+    csv_url: str,
+    batch_size: int,
+    parallel: bool,
+    concurrency: int,
+    id_prop_by_name: dict,
+) -> str:
+    from_expr = build_md5_expression("row", spec.from_id_fields)
+    to_expr = build_md5_expression("row", spec.to_id_fields)
+    props_entries = []
+    for pf in spec.prop_fields:
+        props_entries.append(f"`{pf}`: coalesce(row.`{pf}`, '')")
+    props_literal = ", ".join(props_entries)
+    props_clause = f"SET r += {{{props_literal}}}" if props_literal else ""
+    action_lines = [
+        f"WITH row, {from_expr} AS from_id, {to_expr} AS to_id",
+        f"MATCH (a:{spec.from_} {{{id_prop_by_name[spec.from_]}: from_id}})",
+        f"MATCH (b:{spec.to} {{{id_prop_by_name[spec.to]}: to_id}})",
+        f"MERGE (a)-[r:{spec.type}]-(b)",
+    ]
+    if props_clause:
+        action_lines.append(props_clause)
+    if spec.set_source_target:
+        action_lines.extend([
+            f"SET r.source_type = coalesce(r.source_type, '{spec.from_}')",
+            f"SET r.target_type = coalesce(r.target_type, '{spec.to}')",
+        ])
+    action_query = "\\n".join(action_lines)
+    return (
+        "CALL apoc.periodic.iterate(\n"
+        f"  \"LOAD CSV WITH HEADERS FROM '{csv_url}' AS row RETURN row\",\n"
+        f"  \"{action_query}\",\n"
+        f"  {{batchSize:{batch_size}, parallel:{str(parallel).lower()}, concurrency:{concurrency}}}\n"
+        ");"
+    )
 
 
-def build_id(row: Dict[str, Any], fields: List[str]) -> str:
-    vals = [row.get(f) for f in fields]
-    return md5_id(vals)
-
-
-def node_statements(config_nodes: List[NodeSpec], csv_dir: Path, csv_rows_map):
-    stmts = []
-    for spec in config_nodes:
-        rows = csv_rows_map.get(spec.file, [])
-        for row in rows:
-            node_id = build_id(row, spec.id_fields)
-            props: Dict[str, Any] = {spec.id_property: node_id}
-            for pf in spec.prop_fields:
-                if spec.label == "Category" and pf == "category":
-                    props.setdefault("name", row.get(pf, ""))
-                props[pf] = row.get(pf, "")
-            props_literal = ", ".join([f"`{k}`: '{escape(v)}'" for k, v in props.items()])
-            stmts.append(
-                f"MERGE (n:{spec.label} {{{spec.id_property}: '{node_id}'}}) SET n += {{{props_literal}}};"
-            )
-    return stmts
-
-
-def rel_statements(config_rels: List[RelationshipSpec], config_nodes: List[NodeSpec], csv_rows_map):
-    stmts = []
-    id_prop_by_name = {n.name: n.id_property for n in config_nodes}
-    for spec in config_rels:
-        rows = csv_rows_map.get(spec.file, [])
-        for row in rows:
-            from_id = build_id(row, spec.from_id_fields)
-            to_id = build_id(row, spec.to_id_fields)
-            rel_props: Dict[str, Any] = {}
-            for pf in spec.prop_fields:
-                rel_props[pf] = row.get(pf, "")
-            if spec.set_source_target:
-                rel_props.setdefault("source_type", spec.from_)
-                rel_props.setdefault("target_type", spec.to)
-            props_literal = ", ".join([f"`{k}`: '{escape(v)}'" for k, v in rel_props.items()])
-            if props_literal:
-                props_clause = f" SET r += {{{props_literal}}}"
-            else:
-                props_clause = ""
-            stmts.append(
-                f"MATCH (a:{spec.from_} {{{id_prop_by_name[spec.from_]}: '{from_id}'}}) "
-                f"MATCH (b:{spec.to} {{{id_prop_by_name[spec.to]}: '{to_id}'}}) "
-                f"MERGE (a)-[r:{spec.type}]-(b){props_clause};"
-            )
-    return stmts
+def build_csv_url(csv_dir: Path, filename: str, prefix: str | None, absolute: bool) -> str:
+    if absolute:
+        return (csv_dir / filename).resolve().as_uri()
+    if prefix:
+        base = prefix[:-1] if prefix.endswith("/") else prefix
+        return f"{base}/{filename}"
+    resolved = csv_dir.resolve().as_posix().rstrip("/")
+    return f"file://{resolved}/{filename}"
 
 
 def write_file(path: Path, statements: List[str]):
@@ -81,32 +87,55 @@ def write_file(path: Path, statements: List[str]):
         return
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as f:
-        f.write("\n".join(statements))
+        f.write("\n\n".join(statements))
     print(f"Wrote {len(statements)} statements to {path}")
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Generate Cypher files for nodes and edges from CSVs")
+    parser = argparse.ArgumentParser(description="Generate APOC Cypher files for nodes and edges from CSVs")
     parser.add_argument("--csv-dir", default=str(Path(__file__).parent / "data"), help="Directory with CSV inputs")
     parser.add_argument("--out-dir", default=str(Path(__file__).parent / "cypher_out"), help="Directory to write Cypher files")
+    parser.add_argument("--csv-uri-prefix", help="Override LOAD CSV prefix, e.g. file:///neo4j/import")
+    parser.add_argument("--batch-size", type=int, default=2000)
+    parser.add_argument("--parallel", action="store_true", help="Use APOC parallel batches")
+    parser.add_argument("--concurrency", type=int, default=4)
+    parser.add_argument("--csv-absolute-paths", action="store_true", help="Embed absolute file:/// paths (requires allow_csv_import_from_file_urls=true)")
     args = parser.parse_args()
 
     csv_dir = Path(args.csv_dir)
     out_dir = Path(args.out_dir)
 
     config = DEFAULT_CONFIG
-    csv_rows_map = {}
-    for node in config.nodes:
-        csv_rows_map[node.file] = read_csv(csv_dir / node.file)
-    for rel in config.relationships:
-        if rel.file not in csv_rows_map:
-            csv_rows_map[rel.file] = read_csv(csv_dir / rel.file)
+    nodes_statements: List[str] = []
+    for spec in config.nodes:
+        csv_path = csv_dir / spec.file
+        if not csv_path.exists():
+            continue
+        csv_url = build_csv_url(csv_dir, spec.file, args.csv_uri_prefix, args.csv_absolute_paths)
+        nodes_statements.append(
+            node_statement(spec, csv_url, args.batch_size, args.parallel, args.concurrency)
+        )
 
-    nodes_cypher = node_statements(config.nodes, csv_dir, csv_rows_map)
-    edges_cypher = rel_statements(config.relationships, config.nodes, csv_rows_map)
+    id_prop_by_name = {n.name: n.id_property for n in config.nodes}
+    rel_statements_list: List[str] = []
+    for spec in config.relationships:
+        csv_path = csv_dir / spec.file
+        if not csv_path.exists():
+            continue
+        csv_url = build_csv_url(csv_dir, spec.file, args.csv_uri_prefix, args.csv_absolute_paths)
+        rel_statements_list.append(
+            rel_statement(
+                spec,
+                csv_url,
+                args.batch_size,
+                args.parallel,
+                args.concurrency,
+                id_prop_by_name,
+            )
+        )
 
-    write_file(out_dir / "nodes.cypher", nodes_cypher)
-    write_file(out_dir / "edges.cypher", edges_cypher)
+    write_file(out_dir / "nodes.cypher", nodes_statements)
+    write_file(out_dir / "edges.cypher", rel_statements_list)
 
 
 if __name__ == "__main__":

--- a/agents/generic_loader/generic_csv_loader.py
+++ b/agents/generic_loader/generic_csv_loader.py
@@ -2,10 +2,16 @@ import argparse
 import csv
 import hashlib
 import logging
+import math
+import time
+from itertools import islice
 from pathlib import Path
-from typing import Dict, List, Any
+from typing import Any, Dict, List
 
 from neo4j import GraphDatabase
+from tqdm import tqdm
+
+BATCH_SIZE_DEFAULT = 2000
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
@@ -16,15 +22,7 @@ def md5_id(values: List[Any]) -> str:
     return hashlib.md5(s.encode("utf-8")).hexdigest()
 
 
-def read_csv(path: Path):
-    if not path.exists():
-        log.warning("Missing CSV %s", path)
-        return []
-    with path.open("r", encoding="utf-8") as f:
-        return list(csv.DictReader(f))
-
-
-from schema_models import DEFAULT_CONFIG, LoaderConfig, NodeSpec, RelationshipSpec 
+from schema_models import DEFAULT_CONFIG, LoaderConfig, NodeSpec, RelationshipSpec
 
 
 def build_id(row: Dict[str, Any], fields: List[str]) -> str:
@@ -32,70 +30,113 @@ def build_id(row: Dict[str, Any], fields: List[str]) -> str:
     return md5_id(vals)
 
 
-def merge_nodes(driver, nodes_spec: List[NodeSpec], csv_rows_map):
+def count_rows(path: Path) -> int:
+    if not path.exists():
+        return 0
+    with path.open("r", encoding="utf-8") as f:
+        # subtract header if present
+        line_count = sum(1 for _ in f)
+    return max(0, line_count - 1)
+
+
+def iter_csv_batches(path: Path, size: int):
+    if not path.exists():
+        return
+    with path.open("r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        while True:
+            chunk = list(islice(reader, size))
+            if not chunk:
+                return
+            yield chunk
+
+
+def merge_nodes(driver, nodes_spec: List[NodeSpec], csv_dir: Path, batch_size: int):
     with driver.session() as session:
         for spec in nodes_spec:
-            rows = csv_rows_map.get(spec.file, [])
-            if not rows:
+            path = csv_dir / spec.file
+            row_count = count_rows(path)
+            if row_count == 0:
                 log.info("[nodes] skipping %s (no rows)", spec.name)
                 continue
-            log.info("[nodes] merging %s (%d rows)", spec.name, len(rows))
+            log.info("[nodes] merging %s (%d rows)", spec.name, row_count)
+            start = time.perf_counter()
 
-            def work(tx, row):
-                node_id = build_id(row, spec.id_fields)
-                props = {spec.id_property: node_id}
-                for pf in spec.prop_fields:
-                    # Map category -> name for Category label; otherwise keep as-is
-                    if spec.label == "Category" and pf == "category":
-                        props["name"] = row.get(pf, "")
-                    else:
-                        props[pf] = row.get(pf, "")
-                tx.run(
-                    f"MERGE (n:{spec.label} {{{spec.id_property}: $node_id}}) SET n += $props",
-                    node_id=node_id,
-                    props=props,
-                )
+            cypher = (
+                f"UNWIND $rows AS row "
+                f"MERGE (n:{spec.label} {{{spec.id_property}: row.node_id}}) "
+                f"SET n += row.props"
+            )
 
-            for row in rows:
-                session.execute_write(work, row)
+            total_batches = math.ceil(row_count / batch_size) if row_count else None
+            for chunk in tqdm(
+                iter_csv_batches(path, batch_size),
+                desc=f"nodes:{spec.name}",
+                unit="batch",
+                total=total_batches,
+                leave=False,
+            ):
+                payload = []
+                for row in chunk:
+                    node_id = build_id(row, spec.id_fields)
+                    props = {spec.id_property: node_id}
+                    for pf in spec.prop_fields:
+                        if spec.label == "Category" and pf == "category":
+                            props["name"] = row.get(pf, "")
+                        else:
+                            props[pf] = row.get(pf, "")
+                    payload.append({"node_id": node_id, "props": props})
+                session.execute_write(lambda tx, c=payload: tx.run(cypher, rows=c))
+            log.info("[nodes] %s done in %.2fs", spec.name, time.perf_counter() - start)
 
 
-def merge_relationships(driver, rels_spec: List[RelationshipSpec], nodes_spec_map: List[NodeSpec], csv_rows_map):
+def merge_relationships(driver, rels_spec: List[RelationshipSpec], nodes_spec_map: List[NodeSpec], csv_dir: Path, batch_size: int):
     # Precompute id_property per node name for match clauses
     id_prop_by_name = {n.name: n.id_property for n in nodes_spec_map}
 
     with driver.session() as session:
         for spec in rels_spec:
-            rows = csv_rows_map.get(spec.file, [])
-            if not rows:
+            path = csv_dir / spec.file
+            row_count = count_rows(path)
+            if row_count == 0:
                 log.info("[rels] skipping %s (no rows)", spec.type)
                 continue
-            log.info("[rels] merging %s (%d rows)", spec.type, len(rows))
+            log.info("[rels] merging %s (%d rows)", spec.type, row_count)
+            start = time.perf_counter()
 
-            def work(tx, row):
-                from_id = build_id(row, spec.from_id_fields)
-                to_id = build_id(row, spec.to_id_fields)
-                rel_props = {}
-                for pf in spec.prop_fields:
-                    rel_props[pf] = row.get(pf, "")
-                if spec.set_source_target:
-                    rel_props.setdefault("source_type", spec.from_)
-                    rel_props.setdefault("target_type", spec.to)
+            cypher = (
+                f"UNWIND $rows AS row "
+                f"MATCH (a:{spec.from_} {{{id_prop_by_name[spec.from_]}: row.from_id}}) "
+                f"MATCH (b:{spec.to} {{{id_prop_by_name[spec.to]}: row.to_id}}) "
+                f"MERGE (a)-[r:{spec.type}]-(b) "
+                f"SET r += row.props"
+            )
 
-                tx.run(
-                    f"""
-                    MATCH (a:{spec.from_} {{{id_prop_by_name[spec.from_]}: $from_id}})
-                    MATCH (b:{spec.to} {{{id_prop_by_name[spec.to]}: $to_id}})
-                    MERGE (a)-[r:{spec.type}]-(b)
-                    SET r += $rel_props
-                    """,
-                    from_id=from_id,
-                    to_id=to_id,
-                    rel_props=rel_props,
-                )
-
-            for row in rows:
-                session.execute_write(work, row)
+            total_batches = math.ceil(row_count / batch_size) if row_count else None
+            for chunk in tqdm(
+                iter_csv_batches(path, batch_size),
+                desc=f"rels:{spec.type}",
+                unit="batch",
+                total=total_batches,
+                leave=False,
+            ):
+                payload = []
+                for row in chunk:
+                    from_id = build_id(row, spec.from_id_fields)
+                    to_id = build_id(row, spec.to_id_fields)
+                    rel_props = {}
+                    for pf in spec.prop_fields:
+                        rel_props[pf] = row.get(pf, "")
+                    if spec.set_source_target:
+                        rel_props.setdefault("source_type", spec.from_)
+                        rel_props.setdefault("target_type", spec.to)
+                    payload.append({
+                        "from_id": from_id,
+                        "to_id": to_id,
+                        "props": rel_props,
+                    })
+                session.execute_write(lambda tx, c=payload: tx.run(cypher, rows=c))
+            log.info("[rels] %s done in %.2fs", spec.type, time.perf_counter() - start)
 
 
 def main():
@@ -104,21 +145,16 @@ def main():
     parser.add_argument("--uri", default="bolt://localhost:7687")
     parser.add_argument("--user", default="neo4j")
     parser.add_argument("--password", required=True)
+    parser.add_argument("--batch-size", type=int, default=BATCH_SIZE_DEFAULT, help="Rows per UNWIND batch (default 2000)")
     args = parser.parse_args()
 
     csv_dir = Path(args.csv_dir)
-    csv_rows_map = {}
     config = DEFAULT_CONFIG
-    for node in config.nodes:
-        csv_rows_map[node.file] = read_csv(csv_dir / node.file)
-    for rel in config.relationships:
-        if rel.file not in csv_rows_map:
-            csv_rows_map[rel.file] = read_csv(csv_dir / rel.file)
 
     driver = GraphDatabase.driver(args.uri, auth=(args.user, args.password))
     try:
-        merge_nodes(driver, config.nodes, csv_rows_map)
-        merge_relationships(driver, config.relationships, config.nodes, csv_rows_map)
+        merge_nodes(driver, config.nodes, csv_dir, args.batch_size)
+        merge_relationships(driver, config.relationships, config.nodes, csv_dir, args.batch_size)
         log.info("✅ Generic CSV load complete")
     finally:
         driver.close()

--- a/agents/generic_loader/search.py
+++ b/agents/generic_loader/search.py
@@ -1,0 +1,155 @@
+"""Semantic similarity search over graph nodes using stored embeddings.
+
+This script embeds a text query with the same model used in embed_nodes.py
+and computes cosine similarity (dot product of normalized vectors) against
+nodes' `embedding` property. Results are returned from Neo4j with scores.
+
+Usage (from repo root):
+  python agents/generic_loader/search.py \
+    --label Step \
+    --q "align sequences" \
+    --k 10 \
+    --uri bolt://localhost:7687 \
+    --user neo4j \
+    --password YOUR_PASSWORD
+"""
+
+import argparse
+import logging
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+from neo4j import GraphDatabase
+from sentence_transformers import SentenceTransformer
+
+from schema_models import DEFAULT_CONFIG
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
+
+
+def id_prop_by_label() -> Dict[str, str]:
+    return {spec.label: spec.id_property for spec in DEFAULT_CONFIG.nodes}
+
+
+def fetch_workflow_details(driver, workflow_ids: List[Any]) -> Dict[Any, Dict[str, Any]]:
+    if not workflow_ids:
+        return {}
+    q = (
+        "MATCH (w:Workflow) WHERE w.workflow_id IN $ids\n"
+        "OPTIONAL MATCH (w)-[:HAS_STEP]->(s:Step)\n"
+        "OPTIONAL MATCH (s)-[:STEP_REQUIRES]->(i:Input)\n"
+        "OPTIONAL MATCH (s)-[:STEP_GENERATES]->(o:Output)\n"
+        "RETURN w.workflow_id AS id, w.workflow_repository AS repo, w.file_name AS file, w.category AS category, \n"
+        "       w.number_of_steps AS num_steps, w.readme_content AS readme, \n"
+        "       collect(DISTINCT i.name) AS inputs, collect(DISTINCT o.name) AS outputs"
+    )
+    out: Dict[Any, Dict[str, Any]] = {}
+    with driver.session() as session:
+        for rec in session.run(q, ids=workflow_ids):
+            out[rec["id"]] = {
+                "repo": rec["repo"],
+                "file": rec["file"],
+                "category": rec["category"],
+                "num_steps": rec["num_steps"],
+                "readme": rec["readme"],
+                "inputs": [x for x in rec["inputs"] if x],
+                "outputs": [y for y in rec["outputs"] if y],
+            }
+    return out
+
+
+def fetch_label_embeddings(driver, label: str, id_prop: str) -> List[Tuple[Any, Dict[str, Any], List[float]]]:
+    # Return (id, props, embedding)
+    q = f"MATCH (n:{label}) WHERE n.embedding IS NOT NULL RETURN n.{id_prop} AS id, n AS n, n.embedding AS e"
+    out = []
+    with driver.session() as session:
+        for rec in session.run(q):
+            out.append((rec["id"], dict(rec["n"]), rec["e"]))
+    return out
+
+
+def compute_scores(emb_matrix: np.ndarray, q_vec: np.ndarray) -> np.ndarray:
+    # Both are normalized (embed_nodes stored normalized vectors). Cosine = dot.
+    return emb_matrix @ q_vec
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Semantic search over nodes by label")
+    parser.add_argument("--label", required=True, help="Node label (e.g., Step, Tool, Workflow)")
+    parser.add_argument("--q", required=True, help="Query text")
+    parser.add_argument("--k", type=int, default=10, help="Top K results")
+    parser.add_argument("--uri", default="bolt://localhost:7687")
+    parser.add_argument("--user", default="neo4j")
+    parser.add_argument("--password", required=True)
+    parser.add_argument("--model", default="sentence-transformers/all-MiniLM-L6-v2")
+    args = parser.parse_args()
+
+    id_map = id_prop_by_label()
+    if args.label not in id_map:
+        raise SystemExit(f"Unknown label {args.label}. Known: {sorted(id_map.keys())}")
+
+    log.info("Loading model: %s", args.model)
+    model = SentenceTransformer(args.model)
+    is_e5 = "e5" in args.model.lower()
+    q_text = ("query: " + args.q) if is_e5 else args.q
+    q_vec = model.encode([q_text], normalize_embeddings=True)[0]
+
+    driver = GraphDatabase.driver(args.uri, auth=(args.user, args.password))
+    try:
+        rows = fetch_label_embeddings(driver, args.label, id_map[args.label])
+        if not rows:
+            print("No nodes with embeddings found for label", args.label)
+            return
+
+        ids = [r[0] for r in rows]
+        props = [r[1] for r in rows]
+        mat = np.array([r[2] for r in rows], dtype=np.float32)
+        scores = compute_scores(mat, np.asarray(q_vec, dtype=np.float32))
+
+        top_idx = np.argsort(-scores)[: args.k]
+
+        wf_details = fetch_workflow_details(driver, [ids[i] for i in top_idx]) if args.label == "Workflow" else {}
+
+        print(f"Top {args.k} for label {args.label} and query: {args.q}")
+        for rank, i in enumerate(top_idx, 1):
+            s = float(scores[i])
+            p = props[i]
+            node_id = ids[i]
+
+            if args.label == "Step":
+                title = " | ".join(
+                    [str(x) for x in [p.get("name"), p.get("type"), p.get("tool_id"), p.get("tool_version")] if x]
+                )
+                print(f"{rank:2d}. score={s:.4f} id={node_id} :: {title}")
+            elif args.label == "Workflow":
+                detail = wf_details.get(node_id, {})
+                repo = detail.get("repo") or p.get("workflow_repository")
+                file = detail.get("file") or p.get("file_name")
+                cat = detail.get("category") or p.get("category")
+                steps = detail.get("num_steps") or p.get("number_of_steps")
+                inputs = detail.get("inputs") or []
+                outputs = detail.get("outputs") or []
+                readme = detail.get("readme") or ""
+                if readme and len(readme) > 800:
+                    readme = readme[:800] + "..."
+                print(f"{rank:2d}. score={s:.4f} id={node_id}")
+                print(f"    Workflow: {repo}/{file} | Category: {cat} | Steps: {steps}")
+                if inputs:
+                    print(f"    Inputs: {', '.join(inputs[:20])}")
+                if outputs:
+                    print(f"    Outputs: {', '.join(outputs[:20])}")
+                if readme:
+                    print(f"    README: {readme}")
+            elif args.label == "Tool":
+                title = " | ".join([str(x) for x in [p.get("name"), p.get("version"), p.get("owner")] if x])
+                print(f"{rank:2d}. score={s:.4f} id={node_id} :: {title}")
+            else:
+                title = ", ".join([f"{k}={v}" for k, v in list(p.items())[:5]])
+                print(f"{rank:2d}. score={s:.4f} id={node_id} :: {title}")
+    finally:
+        driver.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/utilities/tools_metadata_downloader/tool_downloader.py
+++ b/utilities/tools_metadata_downloader/tool_downloader.py
@@ -29,11 +29,9 @@ if not galaxy_url or not api_key:
 
 # Get non-sensitive config values
 timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-output_file = (
-    f"utilities/tools_metadata_downloader/data/galaxy_instance_tools_{timestamp}.json"
-)
+output_file = f"utilities/tools_metadata_downloader/data/galaxy_instance_tools_{timestamp}.json"
 max_workers = config["processing"]["max_workers"]
-tool_limit = config["processing"].get("tool_limit", 1000)
+tool_limit = config["processing"].get("tool_limit", None)
 categories_config = config.get("categories", {})
 
 # Connect to Galaxy
@@ -64,14 +62,8 @@ else:
         if num_tools == 0 and percentage > 0:
             num_tools = 1
 
-        print(
-            f"Selecting {num_tools} of {len(cat_tools)} tools from {category} ({percentage*100:.1f}%)"
-        )
-        selected_tools = (
-            random.sample(cat_tools, num_tools)
-            if num_tools < len(cat_tools)
-            else cat_tools
-        )
+        print(f"Selecting {num_tools} of {len(cat_tools)} tools from {category} ({percentage*100:.1f}%)")
+        selected_tools = random.sample(cat_tools, num_tools) if num_tools < len(cat_tools) else cat_tools
 
         for tool in selected_tools:
             tool_id = tool.get("id")
@@ -97,7 +89,7 @@ else:
         try:
             # Get tool details
             tool_details = gi.tools.show_tool(tool_id, io_details=True)
-
+            
             # ---- extract human-readable inputs ----
             inputs_clean = []
             for inp in tool_details.get("inputs", []):
@@ -112,17 +104,14 @@ else:
             # ---- extract human-readable outputs ----
             outputs_clean = []
             for out in tool_details.get("outputs", []):
-                outputs_clean.append(
-                    {
-                        "name": out.get("name"),
-                        "format": out.get("format"),
-                    }
-                )
+                outputs_clean.append({
+                    "name": out.get("name"),
+                    "format": out.get("format"),
+                })
+
 
             help_text = ""
-            raw_tool_url = (
-                f"{galaxy_url}/api/tools/{tool_id}/raw_tool_source?key={api_key}"
-            )
+            raw_tool_url = f"{galaxy_url}/api/tools/{tool_id}/raw_tool_source?key={api_key}"
             response = requests.get(raw_tool_url)
             response.raise_for_status()
             tool_xml = response.text
@@ -134,7 +123,7 @@ else:
                 print(f"Extracted help for {tool_id}: {help_text[:50]}...")
             else:
                 print(f"No <help> section found for {tool_id}")
-
+                
             return {
                 "id": tool_id,  # This should already be in the correct format
                 "name": tool.get("name", ""),
@@ -143,7 +132,8 @@ else:
                 "version": tool.get("version", ""),
                 "inputs": inputs_clean,
                 "outputs": outputs_clean,
-                "help": help_text,
+                "help": help_text, 
+                
             }
         except Exception as e:
             print(f"Error fetching details for {tool_id}: {e}")
@@ -151,21 +141,19 @@ else:
 
     tools_json = []
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        future_to_tool = {
-            executor.submit(fetch_tool_details, tool): tool for tool in filtered_tools
-        }
+        future_to_tool = {executor.submit(fetch_tool_details, tool): tool for tool in filtered_tools}
         for future in tqdm(
             as_completed(future_to_tool),
             total=len(filtered_tools),
             desc="Processing tools",
-            bar_format="{l_bar}{percentage:3.0f}%|{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}]",
+            bar_format="{l_bar}{percentage:3.0f}%|{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}]"
         ):
             result = future.result()
             if result:
                 tools_json.append(result)
 
     print(f"Saving {len(tools_json)} tools to '{output_file}'...")
-    with open(output_file, "w", encoding="utf-8") as f:
+    with open(output_file, "w") as f:
         json.dump(tools_json, f, indent=4)
 
 print(f"✅ Done! Results are saved in '{output_file}'.")


### PR DESCRIPTION
This pull request introduces semantic search capabilities to the Neo4j graph pipeline by adding node embedding and search scripts, along with related documentation updates. It also includes minor code cleanups and formatting improvements in the Galaxy tools metadata downloader.

**Semantic search and embedding features:**

* Added `embed_nodes.py` to compute and store text embeddings on graph nodes using a configurable open-source model (default: MiniLM), with optional vector index creation for Neo4j to support semantic search.
* Added `search.py` CLI script to embed a user query and return top-K similar nodes by label, leveraging stored embeddings for semantic similarity search.
* Updated `agents/generic_loader/README.md` with instructions and usage examples for embedding nodes and running semantic search, including details on model selection and index creation. [[1]](diffhunk://#diff-41279cac737f3aeccc9d3ba113effc0a77ee96162d73f93296e30cbbf9059e27R19-R20) [[2]](diffhunk://#diff-41279cac737f3aeccc9d3ba113effc0a77ee96162d73f93296e30cbbf9059e27R68-R91)

**Improvements to Galaxy tools metadata downloader:**

* Changed the default `tool_limit` in `tool_downloader.py` to `None` for unlimited downloads and cleaned up formatting in several places for better readability. [[1]](diffhunk://#diff-2b4ca74166e859e99406f51098555dac67dc02e346d8f70b2fb3a457b8408013L32-R34) [[2]](diffhunk://#diff-2b4ca74166e859e99406f51098555dac67dc02e346d8f70b2fb3a457b8408013L67-R66) [[3]](diffhunk://#diff-2b4ca74166e859e99406f51098555dac67dc02e346d8f70b2fb3a457b8408013L115-R114) [[4]](diffhunk://#diff-2b4ca74166e859e99406f51098555dac67dc02e346d8f70b2fb3a457b8408013R136-R156)